### PR TITLE
Update i2s_audio.rst

### DIFF
--- a/components/i2s_audio.rst
+++ b/components/i2s_audio.rst
@@ -8,7 +8,9 @@ I²S Audio Component
     :image: i2s_audio.svg
 
 The ``i2s_audio`` component allows for sending and receiving audio via I²S.
-This component only works on ESP32 based chips.
+
+.. warning::
+    This component **only** works on ESP32 based chips.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
added a warning clause to use of i2c audio in esp32

